### PR TITLE
Fix: Add version management via __version__ attribute

### DIFF
--- a/src/sip/__init__.py
+++ b/src/sip/__init__.py
@@ -1,4 +1,11 @@
 """Top-level package for SIP."""
 
+import importlib.metadata
+
 __author__ = """Audrey M. Roy Greenfeld"""
 __email__ = "happyherp@users.noreply.github.com"
+
+try:
+    __version__ = importlib.metadata.version("sip")
+except importlib.metadata.PackageNotFoundError:  # pragma: no cover
+    __version__ = "unknown"

--- a/tests/test_sip.py
+++ b/tests/test_sip.py
@@ -1,8 +1,23 @@
 #!/usr/bin/env python
 """Tests for SIP."""
 
+import re
+import toml
+from pathlib import Path
+
+from sip import __version__
 from sip.config import Config
 from sip.test_runner import SipTestResult, SipTestRunner
+
+
+def test_version():
+    """Test version consistency between pyproject.toml and package."""
+    pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
+    pyproject_data = toml.load(pyproject_path)
+    pyproject_version = pyproject_data["project"]["version"]
+    
+    assert __version__ == pyproject_version
+    assert re.match(r"^\d+\.\d+\.\d+$", __version__) is not None
 
 
 def test_config_creation():


### PR DESCRIPTION
This PR adds proper version management by creating a `__version__` attribute in the package's `__init__.py` file that matches the version in pyproject.toml. This follows Python packaging best practices and makes the version information easily accessible programmatically.

Changes:
- Added version extraction from pyproject.toml in `__init__.py`
- Added `__version__` attribute to package namespace
- Added test to verify version consistency

This improvement helps users and tools to programmatically access the package version and ensures version consistency across the codebase.