### PR TITLE
docs: Add naming convention documentation for Makefile goals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,23 @@ export PRINT_HELP_PYSCRIPT
 
 BROWSER := python -c "$$BROWSER_PYSCRIPT"
 
+# NAMING CONVENTION FOR MAKEFILE GOALS:
+# Goals that are called from external sources (not from within this Makefile) should follow
+# the pattern: ACTION_for-USE-CASE
+# 
+# Examples:
+#   - setup_for-openhands: called by .openhands/setup.sh
+#   - ci_for-github-ci-yml: called by .github/workflows/ci.yml
+#   - ci_for-developers: called by developers locally
+#   - check-code_for-self: called by test_runner for self-improvement
+#   - run-pre-commit-checks_for-git-hooks: called by git pre-commit hooks
+#
+# This convention helps distinguish between:
+#   - Internal goals (used only within this Makefile)
+#   - External goals (called from scripts, CI, or other external sources)
+#
+# When adding new goals that will be called externally, please follow this pattern.
+
 help:
 	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation to the Makefile explaining the naming convention for goals that are called from external sources.

## Changes

- Added a detailed comment block in the Makefile explaining the `ACTION_for-USE-CASE` pattern
- Provided concrete examples from existing goals in the repository:
  - `setup_for-openhands`: called by `.openhands/setup.sh`
  - `ci_for-github-ci-yml`: called by `.github/workflows/ci.yml`
  - `ci_for-developers`: called by developers locally
  - `check-code_for-self`: called by test_runner for self-improvement
  - `run-pre-commit-checks_for-git-hooks`: called by git pre-commit hooks
- Explained the distinction between internal goals (used only within the Makefile) and external goals (called from scripts, CI, or other external sources)
- Added guidance for developers to follow this convention when adding new external goals

## Why This Change?

This documentation will help maintain consistency in the Makefile as the project grows, making it easier for contributors to understand the existing patterns and follow them when adding new goals. The naming convention helps distinguish between goals that are internal implementation details versus those that serve as public interfaces for external tools and scripts.

## Testing

- All existing CI checks pass
- No functional changes were made, only documentation added