### PR TITLE
Fix virtual environment warnings in OpenHands environment

### DIFF
--- a/.openhands/setup.sh
+++ b/.openhands/setup.sh
@@ -4,6 +4,9 @@
 
 set -e  # Exit on any error
 
+# Fix virtual environment path for uv in OpenHands environment
+export VIRTUAL_ENV="$(pwd)/.venv"
+
 # Check if we're in the right directory
 if [[ ! -f "pyproject.toml" ]] || [[ ! -f "Makefile" ]]; then
     echo "❌ Error: This script must be run from the SIP project root directory"


### PR DESCRIPTION
## Problem

When running the SIP project in the OpenHands development environment, `uv` commands were showing warnings like:

```
warning: `VIRTUAL_ENV=/openhands/poetry/openhands-ai-5O4_aCHf-py3.12` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
```

This occurred because OpenHands runs in a containerized environment with its own virtual environment, but the SIP project expects to use its own `.venv` directory.

## Solution

**Simple 1-line fix**: Set `VIRTUAL_ENV` to the correct project path in the setup script.

```bash
export VIRTUAL_ENV="$(pwd)/.venv"
```

This replaces the external OpenHands virtual environment path with the project's expected `.venv` path, eliminating warnings without requiring changes to every `uv` command.

## Changes

- Added one line to `.openhands/setup.sh` to set `VIRTUAL_ENV` correctly
- No changes needed to Makefile or any other files
- Maintains backward compatibility

## Testing

- ✅ All CI checks pass without warnings
- ✅ Setup process works cleanly in OpenHands environment  
- ✅ Python interpreter now correctly uses `/workspace/self-dev/.venv/bin/python3`
- ✅ All linting, formatting, type checking, and tests work without virtual environment warnings

## Impact

This fix eliminates the virtual environment warnings with minimal changes, providing a cleaner development experience in OpenHands while maintaining full functionality.